### PR TITLE
Introduce the changes to livestream setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cabcookie/equipment-list.git"
+    "url": "git+https://github.com/mosaikberlin/equipment-list.git"
   },
   "author": "Carsten Koch",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/cabcookie/equipment-list/issues"
+    "url": "https://github.com/mosaikberlin/equipment-list/issues"
   },
-  "homepage": "https://github.com/cabcookie/equipment-list#readme",
+  "homepage": "https://github.com/mosaikberlin/equipment-list#readme",
   "devDependencies": {
     "standard-version": "^9.3.2"
   }


### PR DESCRIPTION
We will have the following setup:

- 2 DSLR cameras (Sony Alpha 6400) connected via HDMI to ATEM
- ATEM pro mini connected via USB C to Mac mini (ProPresenter Mac)
- Mac mini probably needs an extension or dock as the current connections are not sufficient
- The ATEM is used as a video input device for the Mac mini and we will stream directly out of ProPresenter
- The ProPresenter routine needs to be revised
- The lyrics and preacher slides will be added to the video stream
- We might add another case where we prepare most of the connections to reduce setup time
